### PR TITLE
Symbolic package 3.0.0 works with modern SymPy

### DIFF
--- a/build-octave-7.docker
+++ b/build-octave-7.docker
@@ -93,10 +93,9 @@ RUN apt-get --yes update  && \
       zlib1g-dev \
       zip                        && \
     # Install required python packages
-    #   - sympy, see https://savannah.gnu.org/bugs/?58491
     pip3 install --upgrade --no-cache-dir \
       pip                           \
-      sympy==1.5.1               && \
+      sympy==1.10.1              && \
     apt-get --yes clean          && \
     apt-get --yes autoremove     && \
     rm -Rf /var/lib/apt/lists/*

--- a/jupyterlab/Dockerfile
+++ b/jupyterlab/Dockerfile
@@ -28,7 +28,6 @@ RUN chmod 777 /tmp        && \
       imagemagick            \
       tini                && \
     # Install required python packages
-    #   - sympy, see https://savannah.gnu.org/bugs/?58491
     pip3 install --upgrade --no-cache-dir \
       jupyterlab                    \
       octave_kernel                 \
@@ -36,7 +35,7 @@ RUN chmod 777 /tmp        && \
       jupyter-book                  \
       ghp-import                    \
       numpy                         \
-      sympy==1.5.1                  \
+      sympy==1.10.1                 \
       matplotlib                 && \
     apt-get --yes clean          && \
     apt-get --yes autoremove     && \


### PR DESCRIPTION
But there are breaking changes coming in future SymPy that require fixes
in SymPy.  So it seems safest to leave it pinned for now until we
resolve those.  See https://github.com/cbm755/octsympy/issues/1124

- - - - - 

Do users have persistent packages installed alongside these containers?  Is so, merging this is a bad idea b/c it will break folks using `symbolic<=2.9.0`.  In that case, we'd be better waiting for 7.2.0...