### PR TITLE
OpenBLAS: Avoid leaking instruction set of build system

### DIFF
--- a/build-octave-9.docker
+++ b/build-octave-9.docker
@@ -125,6 +125,7 @@ RUN OPENBLAS_VERSION=0.3.28 && \
       INTERFACE64=1      \
       DYNAMIC_ARCH=1     \
       DYNAMIC_OLDER=1    \
+      TARGET=GENERIC     \
       CONSISTENT_FPCSR=1 \
       USE_THREAD=1       \
       USE_OPENMP=1       \


### PR DESCRIPTION
If OpenBLAS is built with `DYNAMIC_ARCH`, it might select baseline kernels that require the instruction set of the platform on which the OpenBLAS library was built unless the baseline target is specified by `TARGET` (see OpenMathLib/OpenBLAS#5563).
Suppose that the OpenBLAS library that was built without `TARGET` on a build system with a processor that supports, e.g., the AVX-512 instruction set. If that library is then used on a processor without AVX-512 instructions, execution fails with a SIGILL (see https://savannah.gnu.org/bugs/?68225 where this was observed for Octave as distributed by Flatpak).

Avoid that by selecting the `GENERIC` target for the baseline kernel for the `DYNAMIC_ARCH` build of OpenBLAS. That is also what Debian uses for the OpenBLAS packages with `DYNAMIC_ARCH` that they distribute:
https://sources.debian.org/src/openblas/0.3.32%2Bds-5/debian/rules#L39

@siko1056: I don't know much about how Docker containers work. Does this change look correct to you?
